### PR TITLE
Add quotes to ssh password.

### DIFF
--- a/app/src/main/java/ru/nsu/bobrofon/easysshfs/mountpointList/mountpoint/MountPoint.java
+++ b/app/src/main/java/ru/nsu/bobrofon/easysshfs/mountpointList/mountpoint/MountPoint.java
@@ -366,7 +366,7 @@ public class MountPoint {
 		@Override
 		protected void onPostExecute(final String hostIp) {
 			final StringBuilder command = new StringBuilder();
-			command.append("echo ").append(getPassword()).append(" | ");
+			command.append("echo '").append(getPassword()).append("' | ");
 			command.append(mRootDir).append("/sshfs");
 			command.append(" -o 'ssh_command=").append(mRootDir).append("/ssh").append(',');
 			command.append(getOptions()).append(",port=").append(getPort()).append("' ");


### PR DESCRIPTION
It avoids special characters contained in the password to be interpreted by the shell.