### PR TITLE
Sshfs reconnect

### DIFF
--- a/app/src/main/java/ru/nsu/bobrofon/easysshfs/mountpointlist/mountpoint/EditFragment.kt
+++ b/app/src/main/java/ru/nsu/bobrofon/easysshfs/mountpointlist/mountpoint/EditFragment.kt
@@ -96,6 +96,22 @@ class EditFragment : EasySSHFSFragment() {
         options.setText(self.options)
         identityFile.setText(self.identityFile)
 
+        auto.setOnCheckedChangeListener { _, isAutoMountEnabled ->
+            val optionList = options.text.split(',').toMutableList()
+
+            if (isAutoMountEnabled) {
+                if (!optionList.contains("reconnect")) {
+                    optionList.add("reconnect")
+                }
+            } else {
+                if (optionList.last() == "reconnect") {
+                    optionList.removeLast()
+                }
+            }
+
+            options.setText(optionList.joinToString(","))
+        }
+
         val menuHost: MenuHost = requireActivity()
         menuHost.addMenuProvider(menuProvider, viewLifecycleOwner, Lifecycle.State.RESUMED)
     }

--- a/app/src/main/java/ru/nsu/bobrofon/easysshfs/mountpointlist/mountpoint/MountPoint.kt
+++ b/app/src/main/java/ru/nsu/bobrofon/easysshfs/mountpointlist/mountpoint/MountPoint.kt
@@ -175,7 +175,9 @@ class MountPoint(
                         + "umask=0,"
                         + "allow_other,"
                         + "uid=9997,"
-                        + "gid=9997")
+                        + "gid=9997,"
+                        + "ServerAliveInterval=15,"
+                        + "ServerAliveCountMax=3")
 
         private const val TAG = "MOUNT_POINT"
 


### PR DESCRIPTION
Let's try to use 'reconnect,ServerAliveInterval=15,ServerAliveCountMax=3' sshfs options by default. Theoretically, it may improve user experience. But in case it'll not, the user may always edit these sshfs options manually.