### PR TITLE
Remove bundled BusyBox binaries

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,8 +94,6 @@ dependencies {
     // implementation "com.github.topjohnwu.libsu:service:${libsuVersion}"
     // Optional: For com.topjohnwu.superuser.io classes
     // implementation "com.github.topjohnwu.libsu:io:${libsuVersion}"
-    // Optional: Bundle prebuilt BusyBox binaries
-    implementation "com.github.topjohnwu.libsu:busybox:${libsuVersion}"
 }
 
 def signingPropsFile = file("signing.properties")

--- a/app/src/main/java/ru/nsu/bobrofon/easysshfs/ShellBuilder.kt
+++ b/app/src/main/java/ru/nsu/bobrofon/easysshfs/ShellBuilder.kt
@@ -1,7 +1,7 @@
+// SPDX-License-Identifier: MIT
 package ru.nsu.bobrofon.easysshfs
 
 import android.util.Log
-import com.topjohnwu.superuser.BusyBoxInstaller
 import com.topjohnwu.superuser.Shell
 import com.topjohnwu.superuser.Shell.Builder
 import ru.nsu.bobrofon.easysshfs.log.AppLog
@@ -26,7 +26,6 @@ object ShellBuilder {
 
     private fun build(): Shell {
         val builder = Builder.create()
-            .setInitializers(BusyBoxInstaller::class::java.get())
 
         return if (isMagiskV27x()) {
             // TODO: remove logging after the following release (or maybe a few releases)
@@ -45,7 +44,6 @@ object ShellBuilder {
 
     private fun isMagiskV27x(): Boolean {
         val sh = Builder.create()
-            .setInitializers(BusyBoxInstaller::class::java.get())
             .setFlags(Shell.FLAG_NON_ROOT_SHELL)
             .build()
 


### PR DESCRIPTION
Starting November 1st, 2025, all new apps and updates to existing apps submitted to Google Play and targeting Android 15+ devices must support 16 KB page sizes.
BusyBox binaries bundled with libsu violate this requirements.

It should be possible to rebuild BusyBox with the required alignment, but it's not a trivial task. It looks like most of Magisk's patches need to be ported to make it work properly on Android. Let's make it a backup plan. For now, using ToyBox should work fine on most devices.